### PR TITLE
The logger file "debug_paytabs.log" is accessible directly from "pub" directory

### DIFF
--- a/Gateway/Http/PaytabsCore.php
+++ b/Gateway/Http/PaytabsCore.php
@@ -245,7 +245,7 @@ abstract class PaytabsHelper
                 $_prefix = date('c') . " " . PAYTABS_PREFIX . "{$severity_str}: ";
                 $_msg = ($_prefix . $msg . PHP_EOL);
 
-                file_put_contents(PAYTABS_DEBUG_FILE_NAME, $_msg, FILE_APPEND);
+                file_put_contents(BP . '/var/log/' . PAYTABS_DEBUG_FILE_NAME, $_msg, FILE_APPEND);
             } catch (\Throwable $th) {
                 // var_export($th);
             }


### PR DESCRIPTION
Issue #40 : The logger file "debug_paytabs.log" is accessible directly from "pub" directory

Fixed the path for `debug_paytabs.log` file.